### PR TITLE
Update README.md with note about Default Up Axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # edgeimpulse-omniverse-replicator-cans
+
+Note: This script expects that your Default Up Axis is set to "Y". This can be changed in `Edit -> Preferences -> Stage -> Default Up Axis`
+
+Failure to use this setting will result in images being generated with 90-degree rotation.
+


### PR DESCRIPTION
I was having trouble with my images showing up with 90-degree rotation, and the camera pointed in an unhelpful direction. Eventually remembered something from another tutorial that talked about Default Up Axis being a configurable this parameter. I switched it from "Z" to "Y" and now my images look much better, and wanted to add it as a note to possibly help others.